### PR TITLE
chore: Minor fixes

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -15,23 +15,39 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version: [ '7.4', '8.3', '8.4' ]
+
     env:
       CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: ${{ matrix.php-version }}
           coverage: xdebug
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
       - name: Install Composer Dependencies
         run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: Code Climate Setup
+        if: ${{ env.CC_TEST_REPORTER_ID != '' }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter && chmod +x ./cc-test-reporter
           ./cc-test-reporter before-build
@@ -39,5 +55,6 @@ jobs:
         run: |
           php vendor/bin/phpunit --color --testdox --coverage-clover clover.xml tests
       - name: Send Report
+        if: ${{ env.CC_TEST_REPORTER_ID != '' && matrix.php-version == '7.4' }}
         run: |
           ./cc-test-reporter after-build -t clover --exit-code $?

--- a/README.md
+++ b/README.md
@@ -298,10 +298,10 @@ $responsePayment = $ipagClient->payment()->getById($transactionId);
 $responsePayment = $ipagClient->payment()->getByUuid($transactionUuid);
 ```
 ```php
-$responsePayment = $ipagClient->payment()->getByUuid($transactionTid);
+$responsePayment = $ipagClient->payment()->getByTid($transactionTid);
 ```
 ```php
-$responsePayment = $ipagClient->payment()->getByUuid($orderId);
+$responsePayment = $ipagClient->payment()->getByOrderId($orderId);
 ```
 
 ### Capturar Pagamento
@@ -315,11 +315,11 @@ $responsePayment = $ipagClient->payment()->captureByUuid($transactionUuid, $amou
 ```
 ou
 ```php
-$responsePayment = $ipagClient->payment()->captureByUuid($transactionTid, $amount);
+$responsePayment = $ipagClient->payment()->captureByTid($transactionTid, $amount);
 ```
 ou
 ```php
-$responsePayment = $ipagClient->payment()->captureByUuid($orderId, $amount);
+$responsePayment = $ipagClient->payment()->captureByOrderId($orderId, $amount);
 ```
 
 ### Cancelar Pagamento
@@ -333,11 +333,11 @@ $responsePayment = $ipagClient->payment()->cancelByUuid($transactionUuid, $amoun
 ```
 ou
 ```php
-$responsePayment = $ipagClient->payment()->cancelByUuid($transactionTid, $amount);
+$responsePayment = $ipagClient->payment()->cancelByTid($transactionTid, $amount);
 ```
 ou
 ```php
-$responsePayment = $ipagClient->payment()->cancelByUuid($orderId, $amount);
+$responsePayment = $ipagClient->payment()->cancelByOrderId($orderId, $amount);
 ```
 
 > Todos os exemplos: [examples/payment/](https://github.com/ipagdevs/ipag-sdk-php/tree/master/examples/payment/)

--- a/src/Model/Address.php
+++ b/src/Model/Address.php
@@ -210,7 +210,7 @@ final class Address extends Model
     }
     public function zipcode(): Mutator
     {
-        return new Mutator(null, fn ($value) => strval(preg_replace('/\D/', '', $value)));
+        return new Mutator(null, fn ($value) => strval(preg_replace('/\D/', '', $value ?? '')));
     }
 
     /**

--- a/src/Model/Attendee.php
+++ b/src/Model/Attendee.php
@@ -39,11 +39,13 @@ final class Attendee extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Boleto.php
+++ b/src/Model/Boleto.php
@@ -39,11 +39,13 @@ final class Boleto extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Charge.php
+++ b/src/Model/Charge.php
@@ -91,11 +91,13 @@ final class Charge extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }
@@ -118,11 +120,13 @@ final class Charge extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Customer.php
+++ b/src/Model/Customer.php
@@ -344,11 +344,13 @@ final class Customer extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+                
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
-
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Holder.php
+++ b/src/Model/Holder.php
@@ -142,11 +142,13 @@ class Holder extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Owner.php
+++ b/src/Model/Owner.php
@@ -78,11 +78,13 @@ class Owner extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/PaymentSubscription.php
+++ b/src/Model/PaymentSubscription.php
@@ -67,11 +67,13 @@ class PaymentSubscription extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Seller.php
+++ b/src/Model/Seller.php
@@ -114,11 +114,13 @@ final class Seller extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Subscription.php
+++ b/src/Model/Subscription.php
@@ -164,11 +164,13 @@ class Subscription extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }
@@ -200,11 +202,13 @@ class Subscription extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }

--- a/src/Model/Token.php
+++ b/src/Model/Token.php
@@ -83,11 +83,13 @@ class Token extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }
@@ -119,11 +121,13 @@ class Token extends Model
         return new Mutator(
             null,
             function ($value, $ctx) {
+                if (is_null($value)) {
+                    return null;
+                }
+
                 $d = \DateTime::createFromFormat('Y-m-d', $value);
 
-                return is_null($value) ||
-                    ($d && $d->format('Y-m-d') === $value) ?
-                    $value : $ctx->raise('inválido');
+                return ($d && $d->format('Y-m-d') === $value) ? $value : $ctx->raise('inválido');
             }
         );
     }


### PR DESCRIPTION
- Corrigir exemplos de métodos do `payment`
- Corrigir warning `preg_replace` no `Address`
- Adicionar suporte para PHP `8.3 `e `8.4` no github actions
- Configurar cache no composer
- Fix DateTime::createFromFormat(): Passing null to parameter 2 ($datetime) of type string is deprecated
